### PR TITLE
add requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+coverage==3.7.1
+flake8==2.2.5
+mccabe==0.2.1
+pep8==1.5.7
+pyflakes==0.8.1


### PR DESCRIPTION
lists all requirements that are necessary to run ./test.sh
so that someone can create a virtualenv and run `pip install
-r requirements-dev.txt`
