### PR TITLE
force utf8 mode when sys.stdout.encoding is ASCII

### DIFF
--- a/peru/main.py
+++ b/peru/main.py
@@ -294,7 +294,21 @@ CommandParams = collections.namedtuple(
     'CommandParams', ['args', 'runtime', 'scope', 'imports'])
 
 
+def force_utf8_in_ascii_mode_hack():
+    '''In systems without a UTF8 locale configured, python will default to
+    ASCII mode for stdout and stderr. That causes our fancy display to fail
+    with encoding errors. This is a hack to force emitting UTF8 in that
+    case.'''
+    if sys.stdout.encoding == 'ANSI_X3.4-1968':
+        sys.stdout = open(sys.stdout.fileno(), mode='w', encoding='utf8',
+                          buffering=1)
+        sys.stderr = open(sys.stderr.fileno(), mode='w', encoding='utf8',
+                          buffering=1)
+
+
 def main(*, argv=None, env=None, nocatch=False):
+    force_utf8_in_ascii_mode_hack()
+
     if argv is None:
         argv = sys.argv[1:]
     if env is None:


### PR DESCRIPTION
In some environments (particularly Docker), Python tends to start up
with the locale set to ASCII. That means trying to print unicode
characters raises an exception, like in our fancy display. Rather than
requiring the user to explicitly set PYTHONIOENCODING=utf8, we
explicitly rewrap stdout and stderr in UTF8 file objects.

I'm a little worried that this will break something down the line...

https://github.com/buildinspace/peru/issues/136