### PR TITLE
adding module list command

### DIFF
--- a/peru/main.py
+++ b/peru/main.py
@@ -221,6 +221,31 @@ def do_override(params):
             print('{}: {}'.format(module, params.runtime.get_override(module)))
 
 
+@peru_command('module', '''\
+Usage:
+    peru module <list> [-z]
+
+Options:
+    -z              print one module per line for machine-readable formatting
+
+''')
+def do_list(params):
+    modules = params.scope.modules.values()
+    output = ''
+    delim = ' | ' if params.args['-z'] else "\n  "
+
+    for module in modules:
+        output += module.name
+        for field, val in module.plugin_fields.items():
+            output += '{}{}: {}'.format(delim, field, val)
+        if(params.runtime.get_override(module.name)):
+            output += '{}{}: {}'.format(delim, 'override', params.runtime.get_override(module.name))
+        output += '\n'
+
+    if (output):
+        params.runtime.display.print(output[:-1])
+
+
 def get_version():
     version_file = os.path.join(compat.MODULE_ROOT, 'VERSION')
     with open(version_file) as f:

--- a/peru/main.py
+++ b/peru/main.py
@@ -231,19 +231,22 @@ Options:
 ''')
 def do_list(params):
     modules = params.scope.modules.values()
-    output = ''
-    delim = ' | ' if params.args['-z'] else "\n  "
+    output = []
+    delim = ' | ' if params.args['-z'] else '\n  '
+    indent = '' if params.args['-z'] else '  '
+    newline = '\n'
 
     for module in modules:
-        output += module.name
+        fields = []
+        fields.append(module.name)
         for field, val in module.plugin_fields.items():
-            output += '{}{}: {}'.format(delim, field, val)
+            fields.append('{}{}: {}'.format(indent, field, val))
         if(params.runtime.get_override(module.name)):
-            output += '{}{}: {}'.format(delim, 'override', params.runtime.get_override(module.name))
-        output += '\n'
+            fields.append('{}{}: {}'.format(indent, 'override', params.runtime.get_override(module.name)))        
+        output.append(delim.join(fields))
 
     if (output):
-        params.runtime.display.print(output[:-1])
+        params.runtime.display.print(newline.join(output))
 
 
 def get_version():


### PR DESCRIPTION
Hello! The ops guy at my company (@matro) is interested in using Peru to automate some build tasks. I was wondering if you'd be interested in integrating some sort of `peru module list` command. The code here would list modules in either a human readable format or, if the -z flag is specified, in a format better suited for iteration. Let me know what you think! Thanks!