### PR TITLE
Also allow: peru.yml, .peru.yml and just .peru

### DIFF
--- a/peru/parser.py
+++ b/peru/parser.py
@@ -10,7 +10,7 @@ from .rule import Rule
 from .scope import Scope
 
 
-DEFAULT_PERU_FILE_NAME = 'peru.yaml'
+DEFAULT_PERU_FILENAMES = ['peru.yaml', 'peru.yml', '.peru.yml', '.peru']
 
 
 class ParserError(PrintableError):
@@ -103,7 +103,15 @@ def _extract_modules(blob, name_prefix):
 
 
 def _build_module(name, type, blob, yaml_name):
-    peru_file = typesafe_pop(blob, 'peru file', DEFAULT_PERU_FILE_NAME)
+    peru_filename = DEFAULT_PERU_FILENAMES[0]
+    for filename in DEFAULT_PERU_FILENAMES:
+        try:
+            with open(filename):
+                peru_filename = filename
+                break
+        except:
+            continue
+    peru_file = typesafe_pop(blob, 'peru file', peru_filename)
     recursive = typesafe_pop(blob, 'recursive', None)
     default_rule = _extract_default_rule(blob)
     plugin_fields = blob

--- a/peru/runtime.py
+++ b/peru/runtime.py
@@ -76,7 +76,7 @@ class _Runtime:
                 'If the --file or --sync-dir is set, '
                 'the other must also be set.')
         else:
-            basename = explicit_basename or parser.DEFAULT_PERU_FILE_NAME
+            basename = explicit_basename or parser.DEFAULT_PERU_FILENAMES[0]
             self.peru_file = find_project_file(os.getcwd(), basename)
             self.sync_dir = os.path.dirname(self.peru_file)
         self.state_dir = (args['--state-dir'] or

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -8,7 +8,7 @@ import peru.cache
 import peru.compat
 import peru.error
 import peru.main
-from peru.parser import DEFAULT_PERU_FILE_NAME
+from peru.parser import DEFAULT_PERU_FILENAMES
 import peru.rule
 import peru.scope
 
@@ -32,7 +32,7 @@ class SyncTest(shared.PeruTest):
         yaml = textwrap.dedent(unformatted_yaml.format(*format_args))
         if dir is None:
             dir = self.test_dir
-        with open(os.path.join(dir, DEFAULT_PERU_FILE_NAME), 'w') as f:
+        with open(os.path.join(dir, DEFAULT_PERU_FILENAMES[0]), 'w') as f:
             f.write(yaml)
 
     def do_integration_test(self, args, expected, *, cwd=None,
@@ -41,7 +41,7 @@ class SyncTest(shared.PeruTest):
             cwd = self.test_dir
         output = run_peru_command(args, cwd, **peru_cmd_kwargs)
         assert_contents(self.test_dir, expected,
-                        excludes=[DEFAULT_PERU_FILE_NAME, '.peru'])
+                        excludes=[DEFAULT_PERU_FILENAMES[0], '.peru'])
         return output
 
     def test_basic_sync(self):


### PR DESCRIPTION
Hi,

It would be nice if alternative names for the `peru.yaml` file were allowed. I see no downsides.

The CI system for GitLab has a file named `.gitlab-ci.yml`, it is less confusing to me if I can also name the Peru configuration file `.peru.yml`.

Cheers!