### PR TITLE
Use contrib.makedirs instead of os.makedirs in cache.py

### DIFF
--- a/peru/cache.py
+++ b/peru/cache.py
@@ -358,8 +358,7 @@ class _Cache:
         tree = tree or (yield from self.get_empty_tree())
         previous_tree = previous_tree or (yield from self.get_empty_tree())
 
-        if not os.path.exists(dest):
-            makedirs(dest)
+        makedirs(dest)
 
         with contextlib.ExitStack() as stack:
 

--- a/peru/cache.py
+++ b/peru/cache.py
@@ -267,7 +267,7 @@ class _Cache:
     @asyncio.coroutine
     def _init_trees(self):
         if not os.path.exists(os.path.join(self.trees_path, 'HEAD')):
-            os.makedirs(self.trees_path)
+            makedirs(self.trees_path)
             with self.clean_git_session() as session:
                 yield from session.init_git_dir()
             # Override any .gitattributes files that might be in the sync dir,
@@ -359,7 +359,7 @@ class _Cache:
         previous_tree = previous_tree or (yield from self.get_empty_tree())
 
         if not os.path.exists(dest):
-            os.makedirs(dest)
+            makedirs(dest)
 
         with contextlib.ExitStack() as stack:
 


### PR DESCRIPTION
Probably only the first of these is needed, because it was
guarding os.makedirs(path) against os.path.exists(path / 'HEAD').

This was causing an error on Windows:

```
C:\dev\dotfiles>peru sync
Traceback (most recent call last):
  File "C:\Python36\Scripts\peru-script.py", line 11, in <module>
    load_entry_point('peru==1.1.0', 'console_scripts', 'peru')()
  File "C:\Python36\lib\site-packages\peru\main.py", line 363, in main
    runtime = async.run_task(Runtime(args, env))
  File "C:\Python36\lib\site-packages\peru\async.py", line 29, in run_task
    return asyncio.get_event_loop().run_until_complete(coro)
  File "C:\Python36\lib\asyncio\base_events.py", line 466, in run_until_complete
    return future.result()
  File "C:\Python36\lib\site-packages\peru\runtime.py", line 20, in Runtime
    yield from r._init_cache()
  File "C:\Python36\lib\site-packages\peru\runtime.py", line 63, in _init_cache
    self.cache = yield from cache.Cache(self.cache_dir)
  File "C:\Python36\lib\site-packages\peru\cache.py", line 251, in Cache
    yield from cache._init_trees()
  File "C:\Python36\lib\site-packages\peru\cache.py", line 270, in _init_trees
    os.makedirs(self.trees_path)
  File "C:\Python36\lib\os.py", line 220, in makedirs
    mkdir(name, mode)
FileExistsError: [WinError 183] Cannot create a file when that file already exists: 'C:\\dev\\dotfiles\\.peru\\cache\\trees'
```