### PR TITLE
Ignore build/ & dist/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ __pycache__
 *.pyc
 .coverage
 peru.egg-info
+build/
+dist/


### PR DESCRIPTION
(Some projects prefer to leave this up to individual global-ignore files, but I noticed you're also ignoring `*.pyc` so it might be OK.)