### PR TITLE
Run peru with `python -m peru` (python -m peru.main still works too)

### DIFF
--- a/peru/__main__.py
+++ b/peru/__main__.py
@@ -1,0 +1,3 @@
+from .main import main
+main()
+

--- a/peru/__main__.py
+++ b/peru/__main__.py
@@ -1,3 +1,2 @@
 from .main import main
 main()
-


### PR DESCRIPTION
This helps recover from "My Python 2&3 got mixed up on Windows!" in the least surprising way.  I'm already used to `py -3 -m pip ...` but I never thought to check for some longer module-name to run for peru.

I'm not aware of any downside to having this file. Please feel free to prove me wrong. :)

Fix #176