### PR TITLE
add the PERU_REEXEC_PYTHON heuristic on Windows

### DIFF
--- a/peru/resources/plugins/bat/bat_plugin.bat
+++ b/peru/resources/plugins/bat/bat_plugin.bat
@@ -1,0 +1,6 @@
+:: Similar to the rsync plugin, which is written in Bash, this plugin is
+:: written as a Windows .bat script. This is a simple test that we can execute
+:: non-Python plugins correctly. This one just echoes a given message into a
+:: file of a given name.
+
+echo %PERU_MODULE_MESSAGE%> "%PERU_SYNC_DEST%\%PERU_MODULE_FILENAME%"

--- a/peru/resources/plugins/bat/plugin.yaml
+++ b/peru/resources/plugins/bat/plugin.yaml
@@ -1,0 +1,4 @@
+sync exe: bat_plugin.bat
+required fields:
+    - filename
+    - message

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -326,9 +326,15 @@ class PluginsTest(shared.PeruTest):
     def test_cp_plugin(self):
         self.do_plugin_test("cp", {"path": self.content_dir}, self.content)
 
-    @unittest.skipIf(os.name == 'nt', 'the rsync plugin is written in bash')
+    @unittest.skipIf(os.name == 'nt', 'the rsync plugin is Unix-only')
     def test_rsync_plugin(self):
         self.do_plugin_test("rsync", {"path": self.content_dir}, self.content)
+
+    @unittest.skipIf(os.name != 'nt', 'the bat plugin is Windows-only')
+    def test_bat_plugin(self):
+        self.do_plugin_test(
+            "bat", {"filename": "xyz", "message": "hello Windows"},
+            {"xyz": "hello Windows\n"})
 
     def test_empty_plugin(self):
         self.do_plugin_test("empty", {}, {})


### PR DESCRIPTION
Normally we prefer to execute plugins directly. This is pretty reliable
on Unix, where scripts can specify their interpreter with a shebang
line.  However, it's not as reliable on Windows, because the
extension-interpreter mapping is a global config. In my experience,
installing and uninstalling a series of different Python interepreter
versions on a Windows machine can break that association, and as a
result break peru, in confusing ways. (Tests have also been broken by
default for this reason on every Windows CI provider I've ever tried.)

To work around this problem, we apply an extra heuristic on Windows: If
a plugin executable filename ends in .py, assume that we should
re-execute the current interpreter (sys.executable) to run that file,
rather than relying on the system shell to find the interpreter. This
fixes peru on systems with broken Python configs, and it makes no
difference in the vast majority of other cases.

For users who want to control this heuristic (either to disable it, or
to force the same behavior on Unix), we define the PERU_REEXEC_PYTHON
env var.

We discussed the previous behavior six years ago as part of
be35c14f9986f5481fc6c0e6aff04f08f401309c. At the time, I didn't want to
special-case Python plugins over any other language. Since then,
repeated problems on Windows have worn me down, particularly related to
CI. With the recent switch to GitHub Actions, I was looking at solving
this config issue yet again for a new platform, and I just decided I'd
rather have a permanent fix.