### PR TITLE
add fetch-tags option to git plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 peru.egg-info
 build/
 dist/
+.venv/*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,17 @@ If you are working on a new feature please add tests to ensure the feature works
 
 Tests are stored in `peru/tests` and verify the current implementation to see how your test will fit in.
 
+## Installing Locally
+
+To test your changes, you can install/uninstall the project locally:
+
+```bash
+make install
+```
+```bash
+make uninstall
+```
+
 ## Making a Pull Request
 
 Once you have made your changes and are ready to make a Pull Request please ensure tests and linting pass locally before pushing to GitHub.

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,14 @@ deps-dev: ## Install development dependencies
 
 ##@ Utility
 
+.PHONY: install
+install: ## Install peru
+	$(PYTHON) setup.py install --user
+
+.PHONY: uninstall
+uninstall: ## Uninstall peru
+	$(PIP) uninstall peru
+
 .PHONY: help
 help:  ## Display this help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m\033[0m\n"} /^[\#a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)

--- a/README.md
+++ b/README.md
@@ -133,6 +133,11 @@ git module vim-solarized:
     url: https://github.com/altercation/vim-colors-solarized
     # Fetch this exact commit, instead of master or main.
     rev: 7a7e5c8818d717084730133ed6b84a3ffc9d0447
+
+git module dracula:
+    url: https://github.com/dracula/vim
+    fetch-tags: true
+    rev: v1.5.0
 ```
 
 The contents of the `dircolors` module are copied to the root of our repo. The
@@ -186,6 +191,12 @@ index 15c758d..7f0e26b 100644
      url: https://github.com/altercation/vim-colors-solarized
 -    rev: 7a7e5c8818d717084730133ed6b84a3ffc9d0447
 +    rev: 528a59f26d12278698bb946f8fb82a63711eec21
+
+ git module dracula:
+     url: https://github.com/dracula/vim
+     fetch-tags: true
+-    rev: v1.5.0
++    rev: v2.0.0
 ```
 
 Peru made three changes:
@@ -231,6 +242,7 @@ For cloning repos. These types all provide the same fields:
 - `rev`: optional, the specific revision/branch/tag to fetch
 - `reup`: optional, the branch/tag to get the latest rev from when running
   `peru reup`
+- `fetch-tags`: optional, whether to fetch the latest tag instead of the latest commit hash when running `peru reup`
 
 The `git` type also supports setting `submodules: false` to skip
 fetching git submodules. Otherwise they're included by default.

--- a/peru/resources/plugins/git/git_plugin.py
+++ b/peru/resources/plugins/git/git_plugin.py
@@ -153,12 +153,16 @@ def plugin_sync(url, rev):
     checkout_tree(url, rev, os.environ['PERU_SYNC_DEST'])
 
 
-def plugin_reup(url, reup):
+def plugin_reup(url, reup, fetchTags):
     reup_output = os.environ['PERU_REUP_OUTPUT']
     repo_path = clone_if_needed(url)
     git_fetch(url, repo_path)
-    output = git(
-        'rev-parse', reup, git_dir=repo_path, capture_output=True).output
+    if fetchTags:
+        output = git('describe', '--tags', '--abbrev=0', git_dir=repo_path,
+                     capture_output=True).output
+    else:
+        output = git(
+            'rev-parse', reup, git_dir=repo_path, capture_output=True).output
     with open(reup_output, 'w') as out_file:
         print('rev:', output.strip(), file=out_file)
 
@@ -188,12 +192,13 @@ def main():
     default_branch = git_default_branch(URL)
     REV = os.environ['PERU_MODULE_REV'] or default_branch
     REUP = os.environ['PERU_MODULE_REUP'] or default_branch
+    FETCH_TAGS = os.environ['PERU_MODULE_FETCH-TAGS'] == 'true'
 
     command = os.environ['PERU_PLUGIN_COMMAND']
     if command == 'sync':
         plugin_sync(URL, REV)
     elif command == 'reup':
-        plugin_reup(URL, REUP)
+        plugin_reup(URL, REUP, FETCH_TAGS)
     else:
         raise RuntimeError('Unknown command: ' + repr(command))
 

--- a/peru/resources/plugins/git/plugin.yaml
+++ b/peru/resources/plugins/git/plugin.yaml
@@ -6,5 +6,6 @@ optional fields:
     - rev
     - reup
     - submodules
+    - fetch-tags
 cache fields:
     - url


### PR DESCRIPTION
specifying `fetch-tags: true` will cause `peru reup` to update the rev to the latest Tag instead of the latest Commit Hash

fix #233 and some part of #193