### PR TITLE
Support installing/running with pipx - fixes #238

### DIFF
--- a/peru/resources/plugins/curl/curl_plugin.py
+++ b/peru/resources/plugins/curl/curl_plugin.py
@@ -10,14 +10,18 @@ import tarfile
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlsplit
 from urllib.request import Request
-import peru.main
 import urllib.request
 import zipfile
+
+try:
+    from peru.main import get_version
+except ModuleNotFoundError:
+    get_version = None
 
 
 def add_user_agent_to_request(request):
     components = [
-        "peru/%s" % peru.main.get_version(),
+        "peru/%s" % get_version() if get_version else "peru",
         urllib.request.URLopener.version
     ]
     request.add_header("User-agent", " ".join(components))


### PR DESCRIPTION
The curl plugin for peru uses the following as its shebang line:

    #! /usr/bin/env python3

If the user is using pipx, then the system Python interpreter — `/usr/bin/env python3` —  likely does not have the peru package installed.

Before this change the curl plugin always uses a `get_version` function from the peru package and therefore will error if the Python interpreter does not have the peru package installed.

After this change the curl plugin can succeed with only standard library modules available.

Fixes #238 